### PR TITLE
Schema validate on build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .ve
+env/
 *.swp
 *~
 /src

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,9 +24,25 @@ import sys
 import os
 import shlex
 import pathlib
+import json
+from jsonschema import Draft4Validator
 
 from recommonmark.transform import AutoStructify
 from recommonmark.parser import CommonMarkParser
+
+# -- Validating the schema -------------------------------------------
+
+# This makes sure that any schemas use in the documentation are valid
+# according to JSON Schema.
+
+# Paths to any schemas to be validated
+schemas = ['../schema/schema.json']
+
+# An exception will be raised if a schema is invalid
+for schema in schemas:
+    with open(schema) as schema_file:
+        data = json.load(schema_file)
+        Draft4Validator.check_schema(data)
 
 # -- General configuration ------------------------------------------------
 


### PR DESCRIPTION
This basically validates the schema (or number of schemas) against the JSON Schema meta-format whenever sphinx-build is run. 

Makes sure we don't accidentally incorporate an invalid schema into the spec.