### PR TITLE
Social economy rebrand

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Social Investment Data Lab Specification (Alpha)
+# Social Economy Data Lab Specification (Alpha)
 
-The Social Investment Data Lab Specification is being developed as a draft data specification for describing social investment by the [Social Economy Data Lab](http://socialeconomydatalab.org). For more information please [contact the Data Lab](http://socialeconomydatalab.org/contact).
+The Social Economy Data Lab Specification is being developed as a draft data specification for describing social investment by the [Social Economy Data Lab](http://socialeconomydatalab.org). For more information please [contact the Data Lab](http://socialeconomydatalab.org/contact).
 
 ## Building the documentation
 

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -4,7 +4,7 @@
 {% block sidebartitle %}
   <a href="{{ pathto(master_doc) }}">
     <img src="http://socialeconomydatalab.org/img/logos/sedl_logo_nobkgd.png" class="logo" />
-    Social Investment Data Lab Specification
+    Social Economy Data Lab Specification
   </a>
   {% include "searchbox.html" %}
 {% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,7 +76,7 @@ source_suffix = ['.rst', '.md']
 master_doc = 'index'
 
 # General information about the project.
-project = 'Social Investment Data Lab Specification (Alpha)'
+project = 'Social Economy Data Lab Specification (Alpha)'
 copyright = '2016-2017, Open Data Services'
 author = 'Open Data Services'
 
@@ -295,7 +295,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'sphinx.tex', 'Social Investment Data Lab Specification (Alpha)',
+    (master_doc, 'sphinx.tex', 'Social Economy Data Lab Specification (Alpha)',
      'Open Data Services', 'manual'),
 ]
 
@@ -337,7 +337,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'sphinx', 'Social Investment Data Lab Specification (Alpha)',
+    (master_doc, 'sphinx', 'Social Economy Data Lab Specification (Alpha)',
      [author], 1)
 ]
 
@@ -352,8 +352,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'sphinx', 'Social Investment Data Lab Specification (Alpha)',
-     author, 'sphinx', 'The Social Investment Data Lab Specification is being developed as a draft data specification for describing social investment.',
+    (master_doc, 'sphinx', 'Social Economy Data Lab Specification (Alpha)',
+     author, 'sphinx', 'The Social Economy Data Lab Specification is being developed as a draft data specification for describing social investment.',
      'Miscellaneous'),
 ]
 

--- a/docs/getting_started/building_blocks.md
+++ b/docs/getting_started/building_blocks.md
@@ -1,8 +1,8 @@
 # Building blocks
 
-A Social Investment Data Lab Specification document is made up of a number of sections which detail the entities that can be described using the specification, and the properties it recognises.
+A Social Economy Data Lab Specification document is made up of a number of sections which detail the entities that can be described using the specification, and the properties it recognises.
 
-The fundamental building block of the Social Investment Data Lab Specification is a **deal**. Deals have a number of direct properties and a number of related entities, including the organisations involved, classifications, financing and transactions, which in turn have properties.
+The fundamental building block of the Social Economy Data Lab Specification is a **deal**. Deals have a number of direct properties and a number of related entities, including the organisations involved, classifications, financing and transactions, which in turn have properties.
 
 For a full list of properties and entities referred to by the Specification, refer to the [Schema](../../schema_reference/).
 

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-The Social Investment Data Lab Specification defines the definitions, data models and guidance required to make data on social investment interoperable.
+The Social Economy Data Lab Specification defines the definitions, data models and guidance required to make data on social investment interoperable.
 
 The Specification is being designed to help people and organisations who want to:
 * Encourage **increased transparency** and **sharing of data** on social investment

--- a/docs/getting_started/use_cases.md
+++ b/docs/getting_started/use_cases.md
@@ -14,7 +14,7 @@ We will draw on use cases to:
 
 ## Use Cases
 
-The four use cases below provide examples of how user needs can be met by the Social Investment Data Lab Specification. Not all user needs can be met by the Specification and the data itself, but by tools and processes built around the Specification.
+The four use cases below provide examples of how user needs can be met by the Social Economy Data Lab Specification. Not all user needs can be met by the Specification and the data itself, but by tools and processes built around the Specification.
 
 ### 1. Maximising the social impact of investment
 

--- a/docs/getting_started/what_is_social_investment.md
+++ b/docs/getting_started/what_is_social_investment.md
@@ -1,6 +1,6 @@
 # What is social investment?
 
-The Social Investment Data Lab Specification doesn’t seek to impose a strict definition of social investment that published data should meet. That decision can be made by the data holders themselves.
+The Social Economy Data Lab Specification doesn’t seek to impose a strict definition of social investment that published data should meet. That decision can be made by the data holders themselves.
 
 Participants in the social investment market may have different concepts of what can be considered as social investment, or ‘true’ social investment.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ Social Economy Data Lab Specification is:
 ## About
 The Social Economy Data Lab Specification is being developed as a draft data specification to describe social investment.
 
-It is an open specification, and you can contribute to its development by participating in the [issue tracker (Github)](https://github.com/SocialInvestmentDataLab/spec/issues), or by getting in contact using the details below.
+It is an open specification, and you can contribute to its development by participating in the [issue tracker (Github)](https://github.com/SocialEconomyDataLab/spec/issues), or by getting in contact using the details below.
 
 ## Support
 For more information please [contact the Data Lab](http://socialeconomydatalab.org/contact).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,24 +1,24 @@
-# Social Investment Data Lab Specification: Documentation (Alpha)
+# Social Economy Data Lab Specification: Documentation (Alpha)
 
 ```eval_rst
 .. attention::
     **This documentation site is a work in progress.**
 
-    The Social Investment Data Lab Specification is being developed as a draft data specification to describe social investment. For more information please `contact the Data Lab`__.
+    The Social Economy Data Lab Specification is being developed as a draft data specification to describe social investment. For more information please `contact the Data Lab`__.
 .. __: http://socialeconomydatalab.org/contact
 
 ```
 
 For open data to be really useful it has to follow a common data model – a specification – so that data from many publishers can be compared.
 
-We are developing the Social Investment Data Lab Specification for this purpose. The Specification ensures that when your data is made available online, it can be easily transferable between different applications.
+We are developing the Social Economy Data Lab Specification for this purpose. The Specification ensures that when your data is made available online, it can be easily transferable between different applications.
 
 This is how we make sure that when you use the data, the results can be compared.
 
 See the [Getting Started](getting_started/index) page for more information.
 
 <!--
-Social Investment Data Lab Specification is:
+Social Economy Data Lab Specification is:
 
 * **Open data driven**: providing a common way to share transparent and interoperable information on social investment.
 * **Easy to use**: offering a simple spreadsheet format for publishing and consuming data, backed up by a structured data model, and developer-friendly JSON serialisation.
@@ -38,7 +38,7 @@ Social Investment Data Lab Specification is:
 
 ```
 ## About
-The Social Investment Data Lab Specification is being developed as a draft data specification to describe social investment.
+The Social Economy Data Lab Specification is being developed as a draft data specification to describe social investment.
 
 It is an open specification, and you can contribute to its development by participating in the [issue tracker (Github)](https://github.com/SocialInvestmentDataLab/spec/issues), or by getting in contact using the details below.
 

--- a/docs/licensing/index.md
+++ b/docs/licensing/index.md
@@ -32,11 +32,11 @@ Here's an example of a license statement based on our recommended CC BY 4.0 lice
 
 > [Organisation] is committed to transparency and we work with 360Giving to publish information about our grants.
 >
-> Using the Social Investment Data Lab Specification, our social investment deals since [Year] are available as [File Type] here.
+> Using the Social Economy Data Lab Specification, our social investment deals since [Year] are available as [File Type] here.
 >
 > This work is licensed under the Creative Commons Attribution 4.0 International License. To view a copy of this license, visit http://creativecommons.org/licenses/by/4.0/. This means the data is freely accessible to anyone to be used and shared as they wish. The data must be attributed to [Organisation].
 >
-> We believe that with better information, social investors can be more effective and strategic decision makers. The Social Investment Data Lab Specification provides support for investors to publish their grants data openly, to understand their data, and to use the data to create online tools that make social investment more effective. For more information, visit http://www.threesixtygiving.org/ -->
+> We believe that with better information, social investors can be more effective and strategic decision makers. The Social Economy Data Lab Specification provides support for investors to publish their grants data openly, to understand their data, and to use the data to create online tools that make social investment more effective. For more information, visit http://www.threesixtygiving.org/ -->
 
 ### Where can I find more information?
 

--- a/docs/licensing/index.md
+++ b/docs/licensing/index.md
@@ -2,7 +2,7 @@
 
 ### About this Guide
 
-This guide is for organisations publishing social investment deal information to the Social Investment Data Standard format. We assume that you have permission to publish the information if you are not the primary owner. For example, if the information was collected or published by donors, subsidiaries or other third parties.
+This guide is for organisations publishing social investment deal information to the Social Economy Data Lab Specification format. We assume that you have permission to publish the information if you are not the primary owner. For example, if the information was collected or published by donors, subsidiaries or other third parties.
 
 ### What is open data?
 
@@ -10,7 +10,7 @@ Open data is data available to everyone to use and share without restrictions. O
 
 You are probably using open data without realising it. An example could be getting around London with real-time travel updates thanks to [CityMapper](https://citymapper.com "Citymapper - The Ultimate Transport App"), which uses open data from Transport for London and OpenStreetMaps amongst others. Or it could be getting up-to-date with the state of the voluntary sector with the [NCVO Almanac](https://data.ncvo.org.uk/ "NCVO UK Civil Society Almanac") which uses open data from the Charity Commission and Companies House.
 
-### Why license Social Investment Data Standard data?
+### Why license Social Economy Data Lab Specification data?
 
 Without a license, data isn't open data and potential users wouldn't know what they are allowed to do with it. We believe that with better information, social investors can be more effective and strategic decision makers. To achieve this, we recommend using an open license which removes restrictions on anyone interested in using, sharing and understanding the grants landscape.
 
@@ -24,7 +24,7 @@ If you are a UK public sector organisation, we encourage you to use the [Open Go
 
 <!-- ### Where to display the license?
 
-As part of publishing to the Social Investment data standard, we encourage publishers to register with our helpdesk, produce, then upload files to their websites. To make the data easy to discover, you can add a page or section to your website that links to the files. This is the best place to display your chosen license. Don't forget to pop our helpdesk a note so we know your data is published and under what license. -->
+As part of publishing to the Social Economy Data Lab Specification, we encourage publishers to register with our helpdesk, produce, then upload files to their websites. To make the data easy to discover, you can add a page or section to your website that links to the files. This is the best place to display your chosen license. Don't forget to pop our helpdesk a note so we know your data is published and under what license. -->
 
 <!-- ### Is there an example of a license statement?
 

--- a/docs/schema_reference/identifiers.md
+++ b/docs/schema_reference/identifiers.md
@@ -80,7 +80,7 @@ In these cases, it's important to know which identifier to pick so that users of
 Search on [org-id.guide](http://org-id.guide) for identifier sources for [UK organisations](http://org-id.guide/?structure=&coverage=GB&subnational=&sector=), [UK charities](http://org-id.guide/?structure=charity&coverage=GB&sector=), or [any other organisation type](http://org-id.guide/).
 
 ### Commonly used identifier lists
-The following identifier lists are often used in Social Investment Data Standard publication:
+The following identifier lists are often used in Social Economy Data Lab Specification publication:
 * [GB-COH](http://org-id.guide/list/GB-COH) - UK Company Number
 * [GB-CHC](http://org-id.guide/list/GB-CHC) (England and Wales), [GB-SC](http://org-id.guide/list/GB-SC) (Scotland), [GB-NIC](http://org-id.guide/list/GB-NIC) (Northern Ireland) - Charity Numbers
 * [GB-MPR](http://org-id.guide/list/GB-MPR) - Mutuals Public Register

--- a/docs/schema_reference/identifiers.md
+++ b/docs/schema_reference/identifiers.md
@@ -15,7 +15,7 @@ Ultimately, change the organisation in the example below to the Social Economy C
 
 While it is possible to uniquely identify most organisations, identifying individual people who have made investments would run up against the issue of data privacy laws.
 
-The Social Investment Data Specification asks you to give identifiers to:
+The Social Economy Data Lab Specification asks you to give identifiers to:
 
 * [Deals](deal-identifier);  
 * [Organisations](organisation-identifier);  

--- a/docs/schema_reference/index.md
+++ b/docs/schema_reference/index.md
@@ -1,6 +1,6 @@
 # Schema Reference
 
-The Social Investment Data Lab Specification is maintained using [JSON Schema](http://json-schema.org). The Schema is the authoritative source for the specification, and defines the structure of an individual deal so that it can be annotated and validated.
+The Social Economy Data Lab Specification is maintained using [JSON Schema](http://json-schema.org). The Schema is the authoritative source for the specification, and defines the structure of an individual deal so that it can be annotated and validated.
 
 When publishing an individual deal or a number of deals, these deals should be packaged into a single, valid JSON file.
 

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://github.com/SocialEconomyDataLab/spec/blob/master/schema/schema.json",
-    "title": "Social Economy Data Lab Specification",
+    "title": "Social Investment Data Lab Specification",
     "description": "A draft schema for describing social investment deals",
     "type": "object",
     "properties": {

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://github.com/SocialEconomyDataLab/spec/blob/master/schema/schema.json",
-    "title": "Social Investment Data Lab Specification",
+    "title": "Social Economy Data Lab Specification",
     "description": "A draft schema for describing social investment deals",
     "type": "object",
     "properties": {


### PR DESCRIPTION
I've updated all references I could find to ["Social Investment Data Lab", "Social Investment Data Standard", ...] and similar strings. I can't see anything obviously missed, but this should be reviewed.

N.B. ignore 042c5dd - since talking to @timgdavies this no longer applies.

See [#32]